### PR TITLE
Fix seed/cfg/steps metadata parsing

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -29,12 +29,26 @@ def _extract_from_workflow(workflow: dict) -> dict:
             if not negative_id and isinstance(inputs.get("negative"), list):
                 negative_id = str(inputs["negative"][0])
 
-            if meta["seed"] is None and isinstance(inputs.get("seed"), (int, float)):
-                meta["seed"] = int(inputs["seed"])
-            if meta["steps"] is None and isinstance(inputs.get("steps"), (int, float)):
-                meta["steps"] = int(inputs["steps"])
-            if meta["cfg"] is None and isinstance(inputs.get("cfg"), (int, float)):
-                meta["cfg"] = float(inputs["cfg"])
+            seed_val = inputs.get("seed")
+            if meta["seed"] is None and isinstance(seed_val, (int, float, str)):
+                try:
+                    meta["seed"] = int(seed_val)
+                except Exception:
+                    pass
+
+            steps_val = inputs.get("steps")
+            if meta["steps"] is None and isinstance(steps_val, (int, float, str)):
+                try:
+                    meta["steps"] = int(steps_val)
+                except Exception:
+                    pass
+
+            cfg_val = inputs.get("cfg")
+            if meta["cfg"] is None and isinstance(cfg_val, (int, float, str)):
+                try:
+                    meta["cfg"] = float(cfg_val)
+                except Exception:
+                    pass
 
     if not positive_id and not negative_id:
         for node_id, node in workflow.items():

--- a/web/js/loadimagex.js
+++ b/web/js/loadimagex.js
@@ -90,14 +90,19 @@ function extractPromptsFromWorkflow(workflow) {
                     negativeNodeId = String(node.inputs.negative[0]);
                 }
 
-                if (prompts.seed === null && typeof node.inputs.seed === "number") {
-                    prompts.seed = node.inputs.seed;
+                const seedVal = node.inputs.seed;
+                if (prompts.seed === null && (typeof seedVal === "number" || (typeof seedVal === "string" && !isNaN(parseInt(seedVal))))) {
+                    prompts.seed = parseInt(seedVal);
                 }
-                if (prompts.steps === null && typeof node.inputs.steps === "number") {
-                    prompts.steps = node.inputs.steps;
+
+                const stepsVal = node.inputs.steps;
+                if (prompts.steps === null && (typeof stepsVal === "number" || (typeof stepsVal === "string" && !isNaN(parseInt(stepsVal))))) {
+                    prompts.steps = parseInt(stepsVal);
                 }
-                if (prompts.cfg === null && typeof node.inputs.cfg === "number") {
-                    prompts.cfg = node.inputs.cfg;
+
+                const cfgVal = node.inputs.cfg;
+                if (prompts.cfg === null && (typeof cfgVal === "number" || (typeof cfgVal === "string" && !isNaN(parseFloat(cfgVal))))) {
+                    prompts.cfg = parseFloat(cfgVal);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- handle numeric strings when reading sampler parameters
- relax JS extraction logic to parse string values

## Testing
- `python -m py_compile __init__.py`
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6867f97e10d4832b9a7b702d43c02ed1